### PR TITLE
Fix: correct handling of spaces in path or filename of project file

### DIFF
--- a/BuildSSASTask/BuildSSASTask.ps1
+++ b/BuildSSASTask/BuildSSASTask.ps1
@@ -42,7 +42,7 @@ if(!(Test-Path $projPath))
 }
 
 Write-Host ("Building project")
-$ArgumentList = "$projPath /build"
+$ArgumentList = "`"$projPath`" /build"
 try {
     Start-Process $devenv $ArgumentList -NoNewWindow -PassThru -Wait -Verbose -RedirectStandardError $true
 } catch {


### PR DESCRIPTION
Updated BuildSSASTask.ps1 - added escaped quotes around $projPath to enable building projects with spaces in the path or filename. Fix was tested successfully in my own Azure DevOps Server 2020.1 environment.